### PR TITLE
Infra: Update Kong chart to allow specification of pull secret

### DIFF
--- a/kong/Chart.yaml
+++ b/kong/Chart.yaml
@@ -1,3 +1,4 @@
 name: kong
-version: 0.3.2
+version: 0.3.3
 description: An API Gateway
+apiVersion: v1

--- a/kong/templates/deploy-kong.yaml
+++ b/kong/templates/deploy-kong.yaml
@@ -19,7 +19,7 @@ spec:
       {{- if (not (empty .Values.ImagePullSecrets)) }}
       imagePullSecrets:
       {{- range .Values.ImagePullSecrets }}
-         - name: {{ . }}
+        - name: {{ . }}
       {{- end }}
       {{- end }}
       containers:

--- a/kong/templates/deploy-kong.yaml
+++ b/kong/templates/deploy-kong.yaml
@@ -16,6 +16,12 @@ spec:
       labels:
         app: {{ .Values.Component }}
     spec:
+      {{- if (not (empty .Values.ImagePullSecrets)) }}
+      imagePullSecrets:
+        {{- range .Values.ImagePullSecrets }}
+           - name: {{ . }}
+        {{- end }}
+      {{- end }}
       {{- if eq .Values.IstioSidecar.enabled true }}
       initContainers:
       - args:
@@ -43,7 +49,7 @@ spec:
       {{- end }}
       containers:
       - name: {{.Values.Name}}
-        image: {{.Values.Image}}
+        image: {{ printf "%s/%s" .Values.Registry .Values.Image }}
         imagePullPolicy: {{.Values.ImagePullPolicy}}
         env:
           {{- if eq .Values.DefaultSSL.Override true }}

--- a/kong/templates/deploy-kong.yaml
+++ b/kong/templates/deploy-kong.yaml
@@ -22,31 +22,6 @@ spec:
            - name: {{ . }}
         {{- end }}
       {{- end }}
-      {{- if eq .Values.IstioSidecar.enabled true }}
-      initContainers:
-      - args:
-        - -p
-        - "15001"
-        - -u
-        - "1337"
-        - -m
-        - REDIRECT
-        - -i
-        - 10.16.0.0/14
-        - -x
-        - ""
-        - -d
-        - ""
-        image: {{ .Values.IstioSidecar.hub }}/proxy_init:{{ .Values.IstioSidecar.tag }}
-        imagePullPolicy: IfNotPresent
-        name: istio-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: true
-      {{- end }}
       containers:
       - name: {{.Values.Name}}
         image: {{ printf "%s/%s" .Values.Registry .Values.Image }}
@@ -128,84 +103,10 @@ spec:
             mountPath: /usr/local/kong/ssl/default/
             readOnly: true
           {{- end }}
-      {{- if eq .Values.IstioSidecar.enabled true }}
-      - args:
-        - proxy
-        - sidecar
-        - --configPath
-        - /etc/istio/proxy
-        - --binaryPath
-        - /usr/local/bin/envoy
-        - --serviceCluster
-        - istio-proxy
-        - --drainDuration
-        - 45s
-        - --parentShutdownDuration
-        - 1m0s
-        - --discoveryAddress
-        - istio-pilot.istio-system:15007
-        - --discoveryRefreshDelay
-        - 10s
-        - --zipkinAddress
-        - zipkin.infra:9411
-        - --connectTimeout
-        - 10s
-        - --statsdUdpAddress
-        - istio-statsd-prom-bridge.istio-system:9125
-        - --proxyAdminPort
-        - "15000"
-        - --controlPlaneAuthPolicy
-        - NONE
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: ISTIO_META_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: ISTIO_META_INTERCEPTION_MODE
-          value: REDIRECT
-        image: {{ .Values.IstioSidecar.hub }}/proxyv2:{{ .Values.IstioSidecar.tag }}
-        imagePullPolicy: IfNotPresent
-        name: istio-proxy
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        securityContext:
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /etc/istio/proxy
-          name: istio-envoy
-        - mountPath: /etc/certs/
-          name: istio-certs
-          readOnly: true
-      {{- end }}
       volumes:
       {{- if eq .Values.DefaultSSL.Override true }}
       - name: kong-default-tls
         secret:
           defaultMode: 420
           secretName: kong-default-tls
-      {{- end }}
-      {{- if eq .Values.IstioSidecar.enabled true }}
-      - emptyDir:
-          medium: Memory
-        name: istio-envoy
-      - name: istio-certs
-        secret:
-          optional: true
-          secretName: istio.default
       {{- end }}

--- a/kong/templates/deploy-kong.yaml
+++ b/kong/templates/deploy-kong.yaml
@@ -18,9 +18,9 @@ spec:
     spec:
       {{- if (not (empty .Values.ImagePullSecrets)) }}
       imagePullSecrets:
-        {{- range .Values.ImagePullSecrets }}
-           - name: {{ . }}
-        {{- end }}
+      {{- range .Values.ImagePullSecrets }}
+         - name: {{ . }}
+      {{- end }}
       {{- end }}
       containers:
       - name: {{.Values.Name}}

--- a/kong/templates/deploy-kong.yaml
+++ b/kong/templates/deploy-kong.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
       - name: {{.Values.Name}}
-        image: {{ printf "%s/%s" .Values.Registry .Values.Image }}
+        image: "{{ .Values.Image }}:{{ .Values.Tag }}"
         imagePullPolicy: {{.Values.ImagePullPolicy}}
         env:
           {{- if eq .Values.DefaultSSL.Override true }}

--- a/kong/values.yaml
+++ b/kong/values.yaml
@@ -2,7 +2,6 @@ Component: kong
 Name: kong
 Image: docker.io/kong
 Tag: 0.13.0
-Registry: docker.io
 ImagePullPolicy: IfNotPresent
 ImagePullSecrets: []
 KongDatabase: postgres

--- a/kong/values.yaml
+++ b/kong/values.yaml
@@ -1,13 +1,15 @@
 Component: kong
 Name: kong
 Image: kong:0.13.0
+Registry: docker.io
 ImagePullPolicy: IfNotPresent
+ImagePullSecrets: []
 KongDatabase: postgres
 PostgresHost: kong-postgres
 HostPort: false
 IstioSidecar:
   enabled: false
-  hub: gcr.io/istio-release
+  hub: docker.io/istio-release
   tag: release-1.0-latest-daily
 
 Replicas: 3

--- a/kong/values.yaml
+++ b/kong/values.yaml
@@ -3,14 +3,10 @@ Name: kong
 Image: kong:0.13.0
 Registry: docker.io
 ImagePullPolicy: IfNotPresent
-ImagePullSecrets: []
+ImagePullSecrets: ["secret-name"]
 KongDatabase: postgres
 PostgresHost: kong-postgres
 HostPort: false
-IstioSidecar:
-  enabled: false
-  hub: docker.io/istio-release
-  tag: release-1.0-latest-daily
 
 Replicas: 3
 

--- a/kong/values.yaml
+++ b/kong/values.yaml
@@ -1,9 +1,10 @@
 Component: kong
 Name: kong
-Image: kong:0.13.0
+Image: docker.io/kong
+Tag: 0.13.0
 Registry: docker.io
 ImagePullPolicy: IfNotPresent
-ImagePullSecrets: ["secret-name"]
+ImagePullSecrets: []
 KongDatabase: postgres
 PostgresHost: kong-postgres
 HostPort: false


### PR DESCRIPTION
## Helm Chart Render with secret

```
---
# Source: kong/templates/svc-kong-admin.yaml
apiVersion: v1
kind: Service
metadata:
  name: kong-admin
spec:
  type: ClusterIP
  ports:
  - name: kong-admin
    port: 8001
    targetPort: 8001
    protocol: TCP
  selector:
    app: kong

---
# Source: kong/templates/svc-kong-proxy.yaml
apiVersion: v1
kind: Service
metadata:
  name: kong-proxy
spec:
  type: LoadBalancer
  externalTrafficPolicy: Local
  ports:
  - name: http
    port: 80
    targetPort: 80
    protocol: TCP
  - name: https
    port: 443
    targetPort: 443
    protocol: TCP
  selector:
    app: kong

---
# Source: kong/templates/deploy-kong.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: "release-name-kong"
  labels:
    heritage: "Tiller"
    release: "release-name"
    chart: "kong-0.3.3"
    app: kong
spec:
  selector:
    matchLabels:
      app: kong
  template:
    metadata:
      labels:
        app: kong
    spec:
      imagePullSecrets:
        - name: SECRETNAME
      containers:
      - name: kong
        image: "docker.io/kong:0.13.0"
        imagePullPolicy: IfNotPresent
        env:
          - name: KONG_PROXY_ACCESS_LOG
            value: /dev/stdout
          - name: KONG_PROXY_ERROR_LOG
            value: /dev/stderr
          - name: KONG_ADMIN_ACCESS_LOG
            value: /dev/stdout
          - name: KONG_ADMIN_ERROR_LOG
            value: /dev/stderr
          - name: KONG_DATABASE
            value: postgres
          - name: KONG_PG_HOST
            value: kong-postgres
          - name: KONG_PG_DATABASE
            value: kong
          - name: KONG_PG_USER
            value: kong
          - name: KONG_PG_PASSWORD
            valueFrom:
              secretKeyRef:
                name: kong-postgres
                key: postgresql-password
          - name: KONG_ADMIN_LISTEN
            value: 0.0.0.0:8001
          - name: KONG_PROXY_LISTEN
            value: "0.0.0.0:80, 0.0.0.0:443 ssl"
          - name: KONG_HOST_IP
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: status.podIP
        ports:
        - name: admin
          containerPort: 8001
          protocol: TCP
        - name: proxy
          containerPort: 80
          protocol: TCP
        - name: proxy-ssl
          containerPort: 443
          protocol: TCP
        - name: surf-tcp
          containerPort: 7946
          protocol: TCP
        - name: surf-udp
          containerPort: 7946
          protocol: UDP
        livenessProbe:
          tcpSocket:
            port: 8001
          initialDelaySeconds: 90
          periodSeconds: 10
        readinessProbe:
          httpGet:
            path: /ping
            port: proxy-ssl
            scheme: HTTPS
          initialDelaySeconds: 10
          periodSeconds: 10
      volumes:

```

