### PR TITLE
Fix kong chart

### DIFF
--- a/kong/Chart.yaml
+++ b/kong/Chart.yaml
@@ -1,4 +1,4 @@
 name: kong
-version: 0.4.0
+version: 0.4.1
 description: An API Gateway
 apiVersion: v1

--- a/kong/templates/deploy-kong.yaml
+++ b/kong/templates/deploy-kong.yaml
@@ -63,6 +63,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: KONG_CUSTOM_PLUGINS
+            value: jwtheaders
         ports:
         - name: admin
           containerPort: 8001


### PR DESCRIPTION
You have to specify the custom plugins that are added. I had done this manually in QA when I was testing.