### PR TITLE
Kong graceful termination

### DIFF
--- a/kong/Chart.yaml
+++ b/kong/Chart.yaml
@@ -1,4 +1,4 @@
 name: kong
-version: 0.4.1
+version: 0.4.2
 description: An API Gateway
 apiVersion: v1

--- a/kong/templates/deploy-kong.yaml
+++ b/kong/templates/deploy-kong.yaml
@@ -69,6 +69,13 @@ spec:
                 fieldPath: status.podIP
           - name: KONG_CUSTOM_PLUGINS
             value: jwtheaders
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-c"
+              - "sleep 60 && kong quit -t 60"
         ports:
         - name: admin
           containerPort: 8001
@@ -116,3 +123,4 @@ spec:
           defaultMode: 420
           secretName: kong-default-tls
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.TerminationGracePeriodSeconds | default 90 }}


### PR DESCRIPTION
Nginx doesn't handle SIGTERM normally: http://nginx.org/en/docs/control.html
We have to use a preStop hook to stop it gracefully as per https://medium.com/codecademy-engineering/kubernetes-nginx-and-zero-downtime-in-production-2c910c6a5ed8

I've used the one from the official Kong chart with a longer timeout: https://github.com/Kong/charts/blob/main/charts/kong/values.yaml#L573

This has been tested successfully in QA