### PR TITLE
Disable Kong Server banner

### DIFF
--- a/kong/Chart.yaml
+++ b/kong/Chart.yaml
@@ -1,4 +1,4 @@
 name: kong
-version: 0.4.4
+version: 0.4.5
 description: An API Gateway
 apiVersion: v1

--- a/kong/templates/deploy-kong.yaml
+++ b/kong/templates/deploy-kong.yaml
@@ -73,6 +73,8 @@ spec:
             value: "off"
           - name: KONG_DNS_STALE_TTL
             value: "3600"
+          - name: KONG_SERVER_TOKENS
+            value: "off"
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
This will prevent Kong from including Server version in its HTTP headers.

This has been manually pushed to dev in the meantime.

https://sprinthive.atlassian.net/browse/SAAS-7896